### PR TITLE
chore: bump ubuntu image version to 2204:2023.07.2

### DIFF
--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -13,7 +13,7 @@ View the included _[hello.yml](./hello.yml)_ example.
 description: >
   This is a sample executor using Ubuntu.
 machine:
-  image: ubuntu-2004:202101-01
+  image: ubuntu-2204:2023.07.2
 working_directory: ~/app
 ```
 

--- a/src/executors/tag-build-deploy-executor.yml
+++ b/src/executors/tag-build-deploy-executor.yml
@@ -1,5 +1,5 @@
 description: >
   Simple Ubuntu executor
 machine:
-  image: ubuntu-2004:202201-01
+  image: ubuntu-2204:2023.07.2
 working_directory: ~/app


### PR DESCRIPTION
## Description

- Upgraded ubuntu image version to 2204:2023.07.2 to include Node.js v18.16.1.

Read more [here](https://discuss.circleci.com/t/linux-machine-executor-2023-q3-update/48580) about other software versions(Google Cloud SDK, Docker Compose, Docker, etc.)